### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ First, create bridge interfaces on your appliance and connect each bridge interf
 Connect each WAN end to a physical interface.
 Install and start wanem and use the HTML interface to configure the bandwidth, the delay, the packet loss and the jitter of each interface.
 
-### Installing on Debian
+### Installing on Debian/Ubuntu
 
 ```
-apt-get update
-apt-get install ruby bridge-utils lldp ruby-dev
-gem install sinatra
-gem install thin
+sudo apt update
+sudo apt install ruby bridge-utils lldpd ruby-dev build-essentials
+sudo gem install sinatra
+sudo gem install thin
 git clone https://github.com/PJO2/wanem
 cd wanem
 ruby ./http_main.rb


### PR DESCRIPTION
apt-get is deprecated and there was a typo in the package name lldpd
build-essentials is needed for install thin on a new system
also login with root should be disabled in newer distros