### PR TITLE
systemd unit and readme section fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ apt-get update
 apt-get install build-essential ruby bridge-utils lldpd ruby-dev
 gem install sinatra --no-ri --no-rdoc
 gem install thin --no-ri --no-rdoc
-git clone https://github.com/PJO2/wanem
+git clone https://github.com/mbound/wanem
 cd wanem
 ruby ./http_main.rb
 ```
@@ -70,7 +70,7 @@ dpkg -i ruby2.1-dev_2.1.5-2+deb8u6_amd64.deb
 
 gem install sinatra:1.4.8
 gem install thin
-git clone https://github.com/PJO2/wanem
+git clone https://github.com/mbound/wanem
 cd wanem
 ruby ./http_main.rb
 ```
@@ -93,7 +93,7 @@ yum install bridge-utils lldpd ruby ruby-dev
 gem install sinatra:1.4.8
 gem install thin
 
-git clone https://github.com/PJO2/wanem
+git clone https://github.com/mbound/wanem
 cd wanem
 ruby ./http_main.rb
 ```

--- a/README.md
+++ b/README.md
@@ -23,16 +23,36 @@ First, create bridge interfaces on your appliance and connect each bridge interf
 Connect each WAN end to a physical interface.
 Install and start wanem and use the HTML interface to configure the bandwidth, the delay, the packet loss and the jitter of each interface.
 
-### Installing on Debian
+### Installing on Debian or Ubuntu (tested on 16.04 and 18.04)
 
 ```
 apt-get update
-apt-get install ruby bridge-utils lldp ruby-dev
-gem install sinatra
-gem install thin
+apt-get install build-essential ruby bridge-utils lldpd ruby-dev
+gem install sinatra --no-ri --no-rdoc
+gem install thin --no-ri --no-rdoc
 git clone https://github.com/PJO2/wanem
 cd wanem
 ruby ./http_main.rb
+```
+
+### Autostart with systemd (example on Ubuntu 18.04, should work with 16.04 as well)
+
+On systemd-based distributions, wanem can be auto-started at boot with a simple systemd unit file (provided in the repository).
+Note that this unit is written with the assumptions that:
+ - the service will be started as `root` user
+ - the `http_main.rb` is in `/home/ubuntu/wanem` 
+
+Make sure to change both accordingly before installing the unit.
+
+To install and start the unit:
+```
+sudo cp wanem.service /etc/systemd/system/
+systemctl enable wanem
+systemctl start wanem
+```
+To check the status:
+```
+systemctl status wanem
 ```
 
 

--- a/wanem.service
+++ b/wanem.service
@@ -1,0 +1,13 @@
+# wanem.service
+[Unit]
+Description=Starts Wanem WAN emulator web UI
+
+[Service]
+User=root
+Group=root
+WorkingDirectory=/home/ubuntu/wanem
+Restart=always
+ExecStart=/usr/bin/ruby ./http_main.rb
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This has been tested on recent Ubuntu 16.04 and 18.04 cloud images.

I have created a simple systemd unit to auto-start this on Ubuntu systems using systemd, and have made a few fixes to the readme, including instructions for the systemd unit.

Ruby gems can be installed with `--no-ri` and `--no-doc` flags for most purposes.
Added `build-essential` package for Ubuntu distros and fixed typo for `lldpd` package.